### PR TITLE
feat: 회원가입 및 로그인 기능 구현

### DIFF
--- a/backend/src/main/java/capstone/focus/controller/MemberController.java
+++ b/backend/src/main/java/capstone/focus/controller/MemberController.java
@@ -1,0 +1,33 @@
+package capstone.focus.controller;
+
+import capstone.focus.dto.LoginRequest;
+import capstone.focus.dto.Message;
+import capstone.focus.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import javax.validation.Valid;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/login")
+    public ResponseEntity<?> login(@RequestBody @Valid LoginRequest loginRequest) {
+        if (memberService.isSignUp(loginRequest.getEmail())) {
+            memberService.login(loginRequest);
+            Message message = new Message("Login Success");
+            return ResponseEntity.ok(message);
+        }
+
+        //return ResponseEntity.ok().body(memberService.signUp(loginRequest)).build();
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/capstone/focus/controller/MemberController.java
+++ b/backend/src/main/java/capstone/focus/controller/MemberController.java
@@ -27,7 +27,6 @@ public class MemberController {
             return ResponseEntity.ok(message);
         }
 
-        //return ResponseEntity.ok().body(memberService.signUp(loginRequest)).build();
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok().body(memberService.signUp(loginRequest));
     }
 }

--- a/backend/src/main/java/capstone/focus/domain/Member.java
+++ b/backend/src/main/java/capstone/focus/domain/Member.java
@@ -1,0 +1,35 @@
+package capstone.focus.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    private String name;
+
+    private String email;
+
+    @Column(name = "access_token")
+    private String accessToken;
+
+    @Column(name = "refresh_token")
+    private String refreshToken;
+
+    @Column(name = "expired_at")
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime expiredAt;
+
+}

--- a/backend/src/main/java/capstone/focus/domain/Member.java
+++ b/backend/src/main/java/capstone/focus/domain/Member.java
@@ -32,4 +32,10 @@ public class Member {
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime expiredAt;
 
+    public void update(String name, String accessToken, String refreshToken) {
+        this.name = name;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.expiredAt = LocalDateTime.now().plusHours(1);
+    }
 }

--- a/backend/src/main/java/capstone/focus/domain/Member.java
+++ b/backend/src/main/java/capstone/focus/domain/Member.java
@@ -1,6 +1,7 @@
 package capstone.focus.domain;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -31,6 +32,15 @@ public class Member {
     @Column(name = "expired_at")
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime expiredAt;
+
+    @Builder
+    public Member(String name, String email, String accessToken, String refreshToken, LocalDateTime expiredAt) {
+        this.name = name;
+        this.email = email;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.expiredAt = expiredAt;
+    }
 
     public void update(String name, String accessToken, String refreshToken) {
         this.name = name;

--- a/backend/src/main/java/capstone/focus/dto/LoginRequest.java
+++ b/backend/src/main/java/capstone/focus/dto/LoginRequest.java
@@ -1,9 +1,11 @@
 package capstone.focus.dto;
 
+import capstone.focus.domain.Member;
 import lombok.Getter;
 import lombok.Setter;
 
 import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -18,4 +20,13 @@ public class LoginRequest {
     @NotNull
     private String refreshToken;
 
+    public Member toMember() {
+        return Member.builder()
+                .name(name)
+                .email(email)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .expiredAt(LocalDateTime.now().plusHours(1))
+                .build();
+    }
 }

--- a/backend/src/main/java/capstone/focus/dto/LoginRequest.java
+++ b/backend/src/main/java/capstone/focus/dto/LoginRequest.java
@@ -1,0 +1,21 @@
+package capstone.focus.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+public class LoginRequest {
+
+    @NotNull
+    private String name;
+    @NotNull
+    private String email;
+    @NotNull
+    private String accessToken;
+    @NotNull
+    private String refreshToken;
+
+}

--- a/backend/src/main/java/capstone/focus/dto/Message.java
+++ b/backend/src/main/java/capstone/focus/dto/Message.java
@@ -6,6 +6,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class Message {
+
     private String message;
 
     public Message(String message) {

--- a/backend/src/main/java/capstone/focus/dto/Message.java
+++ b/backend/src/main/java/capstone/focus/dto/Message.java
@@ -1,0 +1,14 @@
+package capstone.focus.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Message {
+    private String message;
+
+    public Message(String message) {
+        this.message = message;
+    }
+}

--- a/backend/src/main/java/capstone/focus/dto/SignUpResponse.java
+++ b/backend/src/main/java/capstone/focus/dto/SignUpResponse.java
@@ -4,11 +4,10 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Getter
-@Setter
 public class SignUpResponse {
 
-    private Long memberId;
-    private String message;
+    private final Long memberId;
+    private final String message;
 
     public SignUpResponse(Long memberId, String message) {
         this.memberId = memberId;

--- a/backend/src/main/java/capstone/focus/dto/SignUpResponse.java
+++ b/backend/src/main/java/capstone/focus/dto/SignUpResponse.java
@@ -1,0 +1,17 @@
+package capstone.focus.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SignUpResponse {
+
+    private Long memberId;
+    private String message;
+
+    public SignUpResponse(Long memberId, String message) {
+        this.memberId = memberId;
+        this.message = message;
+    }
+}

--- a/backend/src/main/java/capstone/focus/repository/MemberRepository.java
+++ b/backend/src/main/java/capstone/focus/repository/MemberRepository.java
@@ -1,0 +1,11 @@
+package capstone.focus.repository;
+
+import capstone.focus.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+}

--- a/backend/src/main/java/capstone/focus/service/MemberService.java
+++ b/backend/src/main/java/capstone/focus/service/MemberService.java
@@ -1,0 +1,35 @@
+package capstone.focus.service;
+
+import capstone.focus.domain.Member;
+import capstone.focus.dto.LoginRequest;
+import capstone.focus.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public boolean isSignUp(String email) {
+        Optional<Member> member = memberRepository.findByEmail(email);
+        return member.isPresent();
+    }
+
+    public void login(LoginRequest loginRequest) {
+        // TODO 해당하는 이메일이 없을 경우 예외 처리
+        Member member = memberRepository.findByEmail(loginRequest.getEmail())
+                .orElseThrow();
+        member.update(loginRequest.getName(), loginRequest.getAccessToken(), loginRequest.getRefreshToken());
+    }
+
+    public void signUp(LoginRequest loginRequest) {
+        // TODO 회원 가입하고 id와 success 메시지 반환
+    }
+
+}

--- a/backend/src/main/java/capstone/focus/service/MemberService.java
+++ b/backend/src/main/java/capstone/focus/service/MemberService.java
@@ -2,6 +2,7 @@ package capstone.focus.service;
 
 import capstone.focus.domain.Member;
 import capstone.focus.dto.LoginRequest;
+import capstone.focus.dto.SignUpResponse;
 import capstone.focus.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,8 +29,12 @@ public class MemberService {
         member.update(loginRequest.getName(), loginRequest.getAccessToken(), loginRequest.getRefreshToken());
     }
 
-    public void signUp(LoginRequest loginRequest) {
-        // TODO 회원 가입하고 id와 success 메시지 반환
+    public SignUpResponse signUp(LoginRequest loginRequest) {
+        Member member = loginRequest.toMember();
+        memberRepository.save(member);
+
+        Long memberId = member.getId();
+        return new SignUpResponse(memberId, "First Login Success");
     }
 
 }


### PR DESCRIPTION
## 📌 이슈번호

- close #3

## 📗 요구 사항과 구현 내용
Spotify 계정으로 로그인 시, 최초 로그인한 경우 회원가입을 진행하여 회원의 정보를 DB에 저장합니다.
이미 가입한 회원인 경우, 회원의 이름, 액세스 토큰, 리프레시 토큰, 토큰 만료 기한 정보를 업데이트합니다.

이미 가입한 회원인지 판별하는 로직은, 회원이 스포티파이에 가입 시 사용한 이메일을 사용하여 구현하였습니다.

## 📖 구현 스크린샷
Postman으로 테스트 완료하였습니다.
![image](https://user-images.githubusercontent.com/63943319/231046500-8ae86681-e0ff-4c94-86f4-f6f3622e932e.png)

![image](https://user-images.githubusercontent.com/63943319/231046524-74b522a6-9cd8-4eaf-8ff1-c5268efe4d93.png)

## 📖 PR 포인트 & 궁금한 점
