### PR TITLE
feat: 책 리스트 조회 기능 구현

### DIFF
--- a/backend/src/main/java/capstone/focus/controller/BookController.java
+++ b/backend/src/main/java/capstone/focus/controller/BookController.java
@@ -1,0 +1,22 @@
+package capstone.focus.controller;
+
+import capstone.focus.dto.BookListResponse;
+import capstone.focus.service.BookService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequiredArgsConstructor
+public class BookController {
+
+    private final BookService bookService;
+
+    @GetMapping("/books")
+    public ResponseEntity<?> bookList(@RequestParam(defaultValue = "0") int page) {
+        BookListResponse bookListResponse = bookService.bookList(page);
+        return ResponseEntity.ok(bookListResponse);
+    }
+}

--- a/backend/src/main/java/capstone/focus/controller/MemberController.java
+++ b/backend/src/main/java/capstone/focus/controller/MemberController.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import javax.validation.Valid;
@@ -19,7 +19,7 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @GetMapping("/login")
+    @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody @Valid LoginRequest loginRequest) {
         if (memberService.isSignUp(loginRequest.getEmail())) {
             memberService.login(loginRequest);
@@ -27,6 +27,6 @@ public class MemberController {
             return ResponseEntity.ok(message);
         }
 
-        return ResponseEntity.ok().body(memberService.signUp(loginRequest));
+        return ResponseEntity.ok(memberService.signUp(loginRequest));
     }
 }

--- a/backend/src/main/java/capstone/focus/domain/Book.java
+++ b/backend/src/main/java/capstone/focus/domain/Book.java
@@ -1,0 +1,26 @@
+package capstone.focus.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "book")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Book {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "book_id")
+    private Long id;
+
+    private String title;
+    private String author;
+    private String description;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+}

--- a/backend/src/main/java/capstone/focus/dto/BookListResponse.java
+++ b/backend/src/main/java/capstone/focus/dto/BookListResponse.java
@@ -1,0 +1,15 @@
+package capstone.focus.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class BookListResponse {
+
+    private final List<BookResponse> books;
+
+    public BookListResponse(List<BookResponse> books) {
+        this.books = books;
+    }
+}

--- a/backend/src/main/java/capstone/focus/dto/BookResponse.java
+++ b/backend/src/main/java/capstone/focus/dto/BookResponse.java
@@ -1,0 +1,21 @@
+package capstone.focus.dto;
+
+import capstone.focus.domain.Book;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class BookResponse {
+    private Long bookId;
+    private String title;
+    private String author;
+    private String description;
+
+    public BookResponse(Book book) {
+        this.bookId = book.getId();
+        this.title = book.getTitle();
+        this.author = book.getAuthor();
+        this.description = book.getDescription();
+    }
+}

--- a/backend/src/main/java/capstone/focus/dto/BookResponse.java
+++ b/backend/src/main/java/capstone/focus/dto/BookResponse.java
@@ -2,15 +2,13 @@ package capstone.focus.dto;
 
 import capstone.focus.domain.Book;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class BookResponse {
-    private Long bookId;
-    private String title;
-    private String author;
-    private String description;
+    private final Long bookId;
+    private final String title;
+    private final String author;
+    private final String description;
 
     public BookResponse(Book book) {
         this.bookId = book.getId();

--- a/backend/src/main/java/capstone/focus/dto/SignUpResponse.java
+++ b/backend/src/main/java/capstone/focus/dto/SignUpResponse.java
@@ -1,7 +1,6 @@
 package capstone.focus.dto;
 
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
 public class SignUpResponse {

--- a/backend/src/main/java/capstone/focus/repository/BookRepository.java
+++ b/backend/src/main/java/capstone/focus/repository/BookRepository.java
@@ -1,0 +1,7 @@
+package capstone.focus.repository;
+
+import capstone.focus.domain.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookRepository extends JpaRepository<Book, Long> {
+}

--- a/backend/src/main/java/capstone/focus/service/BookService.java
+++ b/backend/src/main/java/capstone/focus/service/BookService.java
@@ -27,10 +27,10 @@ public class BookService {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
         Page<Book> books = bookRepository.findAll(pageable);
 
-        List<BookResponse> list = books.stream()
+        List<BookResponse> booksResponse = books.stream()
                 .map(book -> new BookResponse(book))
                 .collect(Collectors.toList());
 
-        return new BookListResponse(list);
+        return new BookListResponse(booksResponse);
     }
 }

--- a/backend/src/main/java/capstone/focus/service/BookService.java
+++ b/backend/src/main/java/capstone/focus/service/BookService.java
@@ -1,0 +1,36 @@
+package capstone.focus.service;
+
+import capstone.focus.domain.Book;
+import capstone.focus.dto.BookListResponse;
+import capstone.focus.dto.BookResponse;
+import capstone.focus.repository.BookRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BookService {
+
+    private final BookRepository bookRepository;
+    private static final int size = 15;
+
+    public BookListResponse bookList(int page) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
+        Page<Book> books = bookRepository.findAll(pageable);
+
+        List<BookResponse> list = books.stream()
+                .map(book -> new BookResponse(book))
+                .collect(Collectors.toList());
+
+        return new BookListResponse(list);
+    }
+}


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- #5

## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
책 리스트 조회 기능을 페이징을 사용하여 구현하였습니다.
한 페이지에 최대 15개의 책 리스트를 볼 수 있습니다.

## 📖 구현 스크린샷
Postman으로 테스트 완료하였습니다.

![image](https://user-images.githubusercontent.com/63943319/232391485-88b1f0ca-127a-44e7-9375-aee300f941f6.png)


## 📖 PR 포인트 & 궁금한 점
