### PR TITLE
feat: 책 및 챕터 상세 정보 조회 기능 구현

### DIFF
--- a/backend/sql/insert_data.sql
+++ b/backend/sql/insert_data.sql
@@ -1,0 +1,6 @@
+insert into book(title) values ("a");
+insert into book(title) values ("b");
+
+insert into chapter(chapter_seq, book_id) values (1, 1);
+insert into chapter(chapter_seq, book_id) values (2, 1);
+insert into chapter(chapter_seq, book_id) values (3, 1);

--- a/backend/src/main/java/capstone/focus/controller/BookController.java
+++ b/backend/src/main/java/capstone/focus/controller/BookController.java
@@ -23,4 +23,9 @@ public class BookController {
     public ResponseEntity<?> bookDetail(@PathVariable Long bookId) {
         return ResponseEntity.ok(bookService.bookDetail(bookId));
     }
+
+    @GetMapping("/books/{bookId}/chapters/{chapterSeq}")
+    public ResponseEntity<?> chapterDetail(@PathVariable Long bookId, @PathVariable int chapterSeq) {
+        return ResponseEntity.ok(bookService.chapterDetail(bookId, chapterSeq));
+    }
 }

--- a/backend/src/main/java/capstone/focus/controller/BookController.java
+++ b/backend/src/main/java/capstone/focus/controller/BookController.java
@@ -1,11 +1,11 @@
 package capstone.focus.controller;
 
-import capstone.focus.dto.BookListResponse;
 import capstone.focus.service.BookService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
@@ -16,7 +16,11 @@ public class BookController {
 
     @GetMapping("/books")
     public ResponseEntity<?> bookList(@RequestParam(defaultValue = "0") int page) {
-        BookListResponse bookListResponse = bookService.bookList(page);
-        return ResponseEntity.ok(bookListResponse);
+        return ResponseEntity.ok(bookService.bookList(page));
+    }
+
+    @GetMapping("/books/{bookId}")
+    public ResponseEntity<?> bookDetail(@PathVariable Long bookId) {
+        return ResponseEntity.ok(bookService.bookDetail(bookId));
     }
 }

--- a/backend/src/main/java/capstone/focus/domain/Chapter.java
+++ b/backend/src/main/java/capstone/focus/domain/Chapter.java
@@ -1,0 +1,27 @@
+package capstone.focus.domain;
+
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@IdClass(ChapterId.class)
+@Table(name = "chapter")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Chapter {
+
+    @Id
+    @Column(name = "chapter_seq")
+    private int seq;
+
+    @Id
+    @ManyToOne
+    @JoinColumn(name = "book_id")
+    private Book book;
+
+    private String description;
+}

--- a/backend/src/main/java/capstone/focus/domain/ChapterId.java
+++ b/backend/src/main/java/capstone/focus/domain/ChapterId.java
@@ -1,8 +1,14 @@
 package capstone.focus.domain;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
 import java.io.Serializable;
 import java.util.Objects;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class ChapterId implements Serializable {
     private int seq;
     private Long book;

--- a/backend/src/main/java/capstone/focus/domain/ChapterId.java
+++ b/backend/src/main/java/capstone/focus/domain/ChapterId.java
@@ -1,0 +1,22 @@
+package capstone.focus.domain;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class ChapterId implements Serializable {
+    private int seq;
+    private Long book;
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof ChapterId))
+            return false;
+        ChapterId other = (ChapterId)obj;
+        return other.seq == this.seq && Objects.equals(other.book, this.book);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(seq + book);
+    }
+}

--- a/backend/src/main/java/capstone/focus/dto/BookDetailResponse.java
+++ b/backend/src/main/java/capstone/focus/dto/BookDetailResponse.java
@@ -1,0 +1,19 @@
+package capstone.focus.dto;
+
+import capstone.focus.domain.Book;
+import lombok.Getter;
+
+@Getter
+public class BookDetailResponse {
+    private final String title;
+    private final String author;
+    private final String description;
+    private final int chapterNumber;
+
+    public BookDetailResponse(Book book, int chapterNumber) {
+        this.title = book.getTitle();
+        this.author = book.getAuthor();
+        this.description = book.getDescription();
+        this.chapterNumber = chapterNumber;
+    }
+}

--- a/backend/src/main/java/capstone/focus/dto/ChapterDetailResponse.java
+++ b/backend/src/main/java/capstone/focus/dto/ChapterDetailResponse.java
@@ -1,0 +1,13 @@
+package capstone.focus.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ChapterDetailResponse {
+
+    private final String description;
+
+    public ChapterDetailResponse(String description) {
+        this.description = description;
+    }
+}

--- a/backend/src/main/java/capstone/focus/repository/ChapterRepository.java
+++ b/backend/src/main/java/capstone/focus/repository/ChapterRepository.java
@@ -1,0 +1,14 @@
+package capstone.focus.repository;
+
+import capstone.focus.domain.Book;
+import capstone.focus.domain.Chapter;
+import capstone.focus.domain.ChapterId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ChapterRepository extends JpaRepository<Chapter, ChapterId> {
+
+    @Query("select count(*) from Chapter ch where ch.book = :book")
+    int chapterNumberOf(@Param("book")Book book);
+}

--- a/backend/src/main/java/capstone/focus/service/BookService.java
+++ b/backend/src/main/java/capstone/focus/service/BookService.java
@@ -1,9 +1,12 @@
 package capstone.focus.service;
 
 import capstone.focus.domain.Book;
+import capstone.focus.domain.Chapter;
+import capstone.focus.domain.ChapterId;
 import capstone.focus.dto.BookDetailResponse;
 import capstone.focus.dto.BookListResponse;
 import capstone.focus.dto.BookResponse;
+import capstone.focus.dto.ChapterDetailResponse;
 import capstone.focus.repository.BookRepository;
 import capstone.focus.repository.ChapterRepository;
 import lombok.RequiredArgsConstructor;
@@ -45,5 +48,14 @@ public class BookService {
         int chapterCount = chapterRepository.chapterNumberOf(book);
 
         return new BookDetailResponse(book, chapterCount);
+    }
+
+    public ChapterDetailResponse chapterDetail(Long bookId, int chapterSeq) {
+        // TODO 해당 seq의 챕터가 없을 경우 예외 처리
+        ChapterId chapterId = new ChapterId(chapterSeq, bookId);
+        Chapter chapter = chapterRepository.findById(chapterId)
+                .orElseThrow();
+
+        return new ChapterDetailResponse(chapter.getDescription());
     }
 }

--- a/backend/src/main/java/capstone/focus/service/BookService.java
+++ b/backend/src/main/java/capstone/focus/service/BookService.java
@@ -1,9 +1,11 @@
 package capstone.focus.service;
 
 import capstone.focus.domain.Book;
+import capstone.focus.dto.BookDetailResponse;
 import capstone.focus.dto.BookListResponse;
 import capstone.focus.dto.BookResponse;
 import capstone.focus.repository.BookRepository;
+import capstone.focus.repository.ChapterRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -20,8 +22,10 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class BookService {
 
-    private final BookRepository bookRepository;
     private static final int size = 15;
+
+    private final BookRepository bookRepository;
+    private final ChapterRepository chapterRepository;
 
     public BookListResponse bookList(int page) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
@@ -32,5 +36,14 @@ public class BookService {
                 .collect(Collectors.toList());
 
         return new BookListResponse(booksResponse);
+    }
+
+    public BookDetailResponse bookDetail(Long bookId) {
+        // TODO 해당 id의 책이 없을 경우 예외 처리
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow();
+        int chapterCount = chapterRepository.chapterNumberOf(book);
+
+        return new BookDetailResponse(book, chapterCount);
     }
 }


### PR DESCRIPTION
## 📌 이슈번호

- close #5

## 📗 요구 사항과 구현 내용
책 상세 정보 조회 기능과 챕터 상세 정보 조회 기능을 구현하였습니다.

`chapter` 테이블은 `book` 테이블과 식별 관계를 맺고 있으며, `book`의 기본 키를 포함한 복합 기본 키를 갖고 있습니다. 따라서 `Chapter` 클래스와 `Book` 클래스의 식별 관계 매핑을 위해 `@IdClass`를 사용하였고, 식별자 클래스로 `ChapterId` 클래스를 생성했습니다.

## 📖 구현 스크린샷
Postman으로 테스트 완료하였습니다.

### 책 상세 정보 조회 API
![image](https://user-images.githubusercontent.com/63943319/232415263-a833f645-8d09-437c-9f9f-3852fc99b255.png)
### 챕터 상세 정보 조회 API
![image](https://user-images.githubusercontent.com/63943319/232415320-3e45afc5-1bb4-4b0a-8331-f5fdcb3f58e5.png)


## 📖 PR 포인트 & 궁금한 점