### PR TITLE
feat: 사용자의 선호 장르 등록 및 변경 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -22,6 +22,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.0'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/sql/insert_data.sql
+++ b/backend/sql/insert_data.sql
@@ -1,6 +1,20 @@
-insert into book(title) values ("a");
-insert into book(title) values ("b");
+insert into book(title) values ('a');
+insert into book(title) values ('b');
 
 insert into chapter(chapter_seq, book_id) values (1, 1);
 insert into chapter(chapter_seq, book_id) values (2, 1);
 insert into chapter(chapter_seq, book_id) values (3, 1);
+
+insert into genre (name)
+values
+('pop'),
+('k-pop'),
+('r-n-b'),
+('hip-hop'),
+('country'),
+('acoustic'),
+('blues'),
+('jazz'),
+('classical'),
+('rock'),
+('none');

--- a/backend/src/main/java/capstone/focus/controller/MemberController.java
+++ b/backend/src/main/java/capstone/focus/controller/MemberController.java
@@ -1,5 +1,6 @@
 package capstone.focus.controller;
 
+import capstone.focus.dto.GenreListRequest;
 import capstone.focus.dto.LoginRequest;
 import capstone.focus.dto.Message;
 import capstone.focus.service.MemberService;
@@ -9,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.SessionAttribute;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
@@ -42,5 +44,12 @@ public class MemberController {
         }
 
         return ResponseEntity.ok(new Message("Logout Success"));
+    }
+
+    @PostMapping("/profile/music-genres")
+    public ResponseEntity<?> updateMusicGenrePreference(@RequestBody @Valid GenreListRequest genreListRequest,
+                                                        @SessionAttribute(name = "member") Long memberId) {
+        memberService.updateGenres(memberId, genreListRequest.getGenres());
+        return ResponseEntity.ok(new Message("success"));
     }
 }

--- a/backend/src/main/java/capstone/focus/controller/MemberController.java
+++ b/backend/src/main/java/capstone/focus/controller/MemberController.java
@@ -47,9 +47,9 @@ public class MemberController {
     }
 
     @PostMapping("/profile/music-genres")
-    public ResponseEntity<?> updateMusicGenrePreference(@RequestBody @Valid GenreListRequest genreListRequest,
-                                                        @SessionAttribute(name = "member") Long memberId) {
-        memberService.updateGenres(memberId, genreListRequest.getGenres());
+    public ResponseEntity<?> registerMusicGenrePreference(@RequestBody @Valid GenreListRequest genreListRequest,
+                                                          @SessionAttribute(name = "member") Long memberId) {
+        memberService.registerGenres(memberId, genreListRequest.getGenres());
         return ResponseEntity.ok(new Message("success"));
     }
 }

--- a/backend/src/main/java/capstone/focus/domain/Genre.java
+++ b/backend/src/main/java/capstone/focus/domain/Genre.java
@@ -1,0 +1,21 @@
+package capstone.focus.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "genre")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Genre {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "genre_id")
+    private int id;
+
+    private String name;
+}

--- a/backend/src/main/java/capstone/focus/domain/MemberGenre.java
+++ b/backend/src/main/java/capstone/focus/domain/MemberGenre.java
@@ -1,0 +1,30 @@
+package capstone.focus.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "member_genre")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberGenre {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_genre_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "genre_id")
+    private Genre genre;
+
+    @Column(name = "is_deleted", columnDefinition = "boolean default false")
+    private boolean isDeleted;
+}

--- a/backend/src/main/java/capstone/focus/domain/MemberGenre.java
+++ b/backend/src/main/java/capstone/focus/domain/MemberGenre.java
@@ -10,7 +10,6 @@ import javax.persistence.*;
 
 @Entity
 @Table(name = "member_genre")
-@SQLDelete(sql = "update member_genre set is_deleted = true WHERE member_genre_id = ?")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberGenre {
@@ -27,9 +26,6 @@ public class MemberGenre {
     @ManyToOne
     @JoinColumn(name = "genre_id")
     private Genre genre;
-
-    @Column(name = "is_deleted", columnDefinition = "boolean default false")
-    private boolean isDeleted;
 
     @Builder
     public MemberGenre(Member member, Genre genre) {

--- a/backend/src/main/java/capstone/focus/domain/MemberGenre.java
+++ b/backend/src/main/java/capstone/focus/domain/MemberGenre.java
@@ -1,6 +1,7 @@
 package capstone.focus.domain;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,4 +28,10 @@ public class MemberGenre {
 
     @Column(name = "is_deleted", columnDefinition = "boolean default false")
     private boolean isDeleted;
+
+    @Builder
+    public MemberGenre(Member member, Genre genre) {
+        this.member = member;
+        this.genre = genre;
+    }
 }

--- a/backend/src/main/java/capstone/focus/domain/MemberGenre.java
+++ b/backend/src/main/java/capstone/focus/domain/MemberGenre.java
@@ -4,11 +4,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.*;
 
 @Entity
 @Table(name = "member_genre")
+@SQLDelete(sql = "update member_genre set is_deleted = true WHERE member_genre_id = ?")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberGenre {

--- a/backend/src/main/java/capstone/focus/dto/GenreListRequest.java
+++ b/backend/src/main/java/capstone/focus/dto/GenreListRequest.java
@@ -1,0 +1,15 @@
+package capstone.focus.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Getter
+@Setter
+public class GenreListRequest {
+
+    @NotNull
+    private List<String> genres;
+}

--- a/backend/src/main/java/capstone/focus/repository/GenreRepository.java
+++ b/backend/src/main/java/capstone/focus/repository/GenreRepository.java
@@ -1,0 +1,9 @@
+package capstone.focus.repository;
+
+import capstone.focus.domain.Genre;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GenreRepository extends JpaRepository<Genre, Integer> {
+
+    Genre findByName(String name);
+}

--- a/backend/src/main/java/capstone/focus/repository/MemberGenreRepository.java
+++ b/backend/src/main/java/capstone/focus/repository/MemberGenreRepository.java
@@ -4,20 +4,13 @@ import capstone.focus.domain.Genre;
 import capstone.focus.domain.Member;
 import capstone.focus.domain.MemberGenre;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface MemberGenreRepository extends JpaRepository<MemberGenre, Long> {
 
-    List<MemberGenre> findByMemberAndIsDeletedFalse(Member member);
+    List<MemberGenre> findByMember(Member member);
 
     Optional<MemberGenre> findByMemberAndGenre(Member member, Genre genre);
-
-    @Modifying
-    @Query("update MemberGenre mg set mg.isDeleted = false where mg.id = :id")
-    void addMemberGenre(@Param("id") Long id);
 }

--- a/backend/src/main/java/capstone/focus/repository/MemberGenreRepository.java
+++ b/backend/src/main/java/capstone/focus/repository/MemberGenreRepository.java
@@ -1,0 +1,23 @@
+package capstone.focus.repository;
+
+import capstone.focus.domain.Genre;
+import capstone.focus.domain.Member;
+import capstone.focus.domain.MemberGenre;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MemberGenreRepository extends JpaRepository<MemberGenre, Long> {
+
+    List<MemberGenre> findByMemberAndIsDeletedFalse(Member member);
+
+    Optional<MemberGenre> findByMemberAndGenre(Member member, Genre genre);
+
+    @Modifying
+    @Query("update MemberGenre mg set mg.isDeleted = false where mg.id = :id")
+    void addMemberGenre(@Param("id") Long id);
+}

--- a/backend/src/main/java/capstone/focus/service/MemberService.java
+++ b/backend/src/main/java/capstone/focus/service/MemberService.java
@@ -62,27 +62,22 @@ public class MemberService {
     }
 
     private void deleteExistingGenres(List<String> newGenres, Member member) {
-        List<MemberGenre> existingMemberGenres = memberGenreRepository.findByMemberAndIsDeletedFalse(member);
+        List<MemberGenre> existingMemberGenres = memberGenreRepository.findByMember(member);
         existingMemberGenres.stream()
                 .filter(existingMemberGenre -> !newGenres.contains(existingMemberGenre.getGenre().getName()))
                 .forEach(memberGenreRepository::delete);
     }
 
     private void updateWithNewGenres(List<String> newGenres, Member member) {
-        for (String name: newGenres) {
+        for (String name : newGenres) {
             Genre newGenre = genreRepository.findByName(name);
-            Optional<MemberGenre> memberGenre = memberGenreRepository.findByMemberAndGenre(member, newGenre);
 
-            if (memberGenre.isPresent()) {
-                memberGenreRepository.addMemberGenre(memberGenre.get().getId());
-                continue;
+            if (memberGenreRepository.findByMemberAndGenre(member, newGenre).isEmpty()) {
+                memberGenreRepository.save(MemberGenre.builder()
+                        .member(member)
+                        .genre(newGenre)
+                        .build());
             }
-
-            memberGenreRepository.save(MemberGenre.builder()
-                    .member(member)
-                    .genre(newGenre)
-                    .build());
         }
     }
-
 }

--- a/backend/src/main/java/capstone/focus/service/MemberService.java
+++ b/backend/src/main/java/capstone/focus/service/MemberService.java
@@ -52,7 +52,7 @@ public class MemberService {
         return member.getId();
     }
 
-    public void updateGenres(Long memberId, List<String> newGenres) {
+    public void registerGenres(Long memberId, List<String> newGenres) {
         // TODO 해당하는 id의 회원이 없을 경우 예외 처리
         Member member = memberRepository.findById(memberId)
                 .orElseThrow();


### PR DESCRIPTION
## 📌 이슈번호

- #10 

## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
사용자의 선호 장르 등록 및 변경 기능을 구현하였습니다.

먼저 사용자(`member`)와 장르(`genre`)는 다대다 관계이므로 두 엔티티를 연결하는 `member_genre` 엔티티를 생성하였으며, 사용자의 선호 장르 등록 및 변경 로직은 다음과 같습니다.
1. 기존의 선호 장르 리스트 `existingMemberGenres`를 가져와서 `newGenres` 리스트에 포함되지 않는 경우에만 해당 엔티티를 삭제합니다.
2. `newGenres` 리스트의 각각의 장르에 대해 `memberGenreRepository.findByMemberAndGenre()`를 사용하여 이미 존재하는지 확인하고, 존재하지 않을 경우에만 새로운 `MemberGenre` 엔티티를 추가합니다.

## 📖 구현 스크린샷
Postman으로 테스트 완료하였습니다.
<img width="635" alt="임시" src="https://github.com/capstone-focus/FOCUS/assets/63943319/a5d4070a-8425-468e-aa5b-a8a31399d21a">


## 📖 PR 포인트 & 궁금한 점
