### PR TITLE
feat: 책 이미지 조회 기능 구현

### DIFF
--- a/backend/sql/ddl.sql
+++ b/backend/sql/ddl.sql
@@ -1,0 +1,38 @@
+create table book (
+       book_id bigint not null auto_increment,
+        author varchar(255) not null,
+        description text not null,
+        image_url varchar(255),
+        title varchar(255) not null unique,
+        primary key (book_id)
+    ) engine=InnoDB;
+
+    create table chapter (
+       book_id bigint not null,
+        chapter_seq integer not null,
+        description text not null,
+        primary key (book_id, chapter_seq),
+        foreign key(book_id) references book(book_id)
+    ) engine=InnoDB;
+
+    create table genre (
+       genre_id integer not null auto_increment,
+        name varchar(255) not null unique,
+        primary key (genre_id)
+    ) engine=InnoDB;
+
+    create table member (
+       member_id bigint not null auto_increment,
+        email varchar(255) not null unique,
+        name varchar(255) not null,
+        primary key (member_id)
+    ) engine=InnoDB;
+
+    create table member_genre (
+       member_genre_id bigint not null auto_increment,
+        genre_id integer not null,
+        member_id bigint not null,
+        primary key (member_genre_id),
+        foreign key(member_id) references member(member_id),
+        foreign key(genre_id) references genre(genre_id)
+    ) engine=InnoDB;

--- a/backend/sql/ddl.sql
+++ b/backend/sql/ddl.sql
@@ -3,14 +3,14 @@ create table book (
         author varchar(255) not null,
         description text not null,
         image_url varchar(255),
-        title varchar(255) not null unique,
+        title varchar(255) not null,
         primary key (book_id)
     ) engine=InnoDB;
 
     create table chapter (
        book_id bigint not null,
         chapter_seq integer not null,
-        description text not null,
+        description text,
         primary key (book_id, chapter_seq),
         foreign key(book_id) references book(book_id)
     ) engine=InnoDB;

--- a/backend/src/main/java/capstone/focus/controller/BookController.java
+++ b/backend/src/main/java/capstone/focus/controller/BookController.java
@@ -7,12 +7,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.UrlResource;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @Slf4j
 public class BookController {

--- a/backend/src/main/java/capstone/focus/controller/BookController.java
+++ b/backend/src/main/java/capstone/focus/controller/BookController.java
@@ -1,7 +1,11 @@
 package capstone.focus.controller;
 
 import capstone.focus.service.BookService;
+import capstone.focus.service.LocalFileService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,9 +14,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @RequiredArgsConstructor
+@Slf4j
 public class BookController {
 
     private final BookService bookService;
+    private final LocalFileService localFileService;
 
     @GetMapping("/books")
     public ResponseEntity<?> bookList(@RequestParam(defaultValue = "0") int page) {
@@ -22,5 +28,20 @@ public class BookController {
     @GetMapping("/books/{bookId}")
     public ResponseEntity<?> bookDetail(@PathVariable Long bookId) {
         return ResponseEntity.ok(bookService.bookDetail(bookId));
+    }
+
+    @GetMapping("/books/{bookId}/image")
+    public ResponseEntity<?> bookImage(@PathVariable Long bookId) {
+        String bookTitle = bookService.getBookTitle(bookId);
+        UrlResource bookImage = localFileService.getBookImage(bookTitle);
+
+        if (bookImage != null) {
+            return ResponseEntity.ok().
+                    contentType(MediaType.IMAGE_JPEG)
+                    .body(bookImage);
+        }
+
+        log.info("Not Found");
+        return ResponseEntity.notFound().build();
     }
 }

--- a/backend/src/main/java/capstone/focus/controller/MemberController.java
+++ b/backend/src/main/java/capstone/focus/controller/MemberController.java
@@ -7,17 +7,13 @@ import capstone.focus.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.SessionAttribute;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @Slf4j
 public class MemberController {
@@ -39,7 +35,7 @@ public class MemberController {
     public ResponseEntity<?> logout(HttpServletRequest request) {
         HttpSession session = request.getSession(false);
         if (session != null) {
-            Long memberId = (Long)session.getAttribute("member");
+            Long memberId = (Long) session.getAttribute("member");
             log.info("memberId: {}", memberId);
             session.invalidate();
         }

--- a/backend/src/main/java/capstone/focus/service/BookService.java
+++ b/backend/src/main/java/capstone/focus/service/BookService.java
@@ -32,7 +32,7 @@ public class BookService {
         Page<Book> books = bookRepository.findAll(pageable);
 
         List<BookResponse> booksResponse = books.stream()
-                .map(book -> new BookResponse(book))
+                .map(BookResponse::new)
                 .collect(Collectors.toList());
 
         return new BookListResponse(booksResponse);
@@ -45,5 +45,12 @@ public class BookService {
         int chapterCount = chapterRepository.chapterNumberOf(book);
 
         return new BookDetailResponse(book, chapterCount);
+    }
+
+    public String getBookTitle(Long bookId) {
+        // TODO 해당 id의 책이 없을 경우 예외 처리
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow();
+        return book.getTitle();
     }
 }

--- a/backend/src/main/java/capstone/focus/service/LocalFileService.java
+++ b/backend/src/main/java/capstone/focus/service/LocalFileService.java
@@ -1,0 +1,42 @@
+package capstone.focus.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.UrlResource;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.File;
+import java.net.MalformedURLException;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class LocalFileService {
+
+    @Value("${book.folder.path}")
+    private String bookFolderPath;
+
+    private final String fileExtension = ".jpg";
+
+    public UrlResource getBookImage(String title) {
+        String imageFilePath = bookFolderPath + title + "\\" + title + fileExtension;
+
+        log.info("imageFilePath: {}", imageFilePath);
+
+        try {
+            File imageFile = new File(imageFilePath);
+            UrlResource imageResource = new UrlResource(imageFile.toURI());
+            if (imageResource.exists() && imageResource.isReadable()) {
+                return imageResource;
+            }
+        } catch (MalformedURLException e) {
+            // TODO 예외 처리
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+}

--- a/backend/src/main/java/capstone/focus/service/RecommendationService.java
+++ b/backend/src/main/java/capstone/focus/service/RecommendationService.java
@@ -81,6 +81,7 @@ public class RecommendationService {
         try {
             response = parseJsonToObject(responseMessage);
         } catch (IOException e) {
+            // TODO 예외처리
             e.printStackTrace();
         }
 


### PR DESCRIPTION
## 📌 이슈번호

- close #16

## 📗 요구 사항과 구현 내용
책 이미지를 조회하는 기능을 구현하였습니다.
구현 로직은 다음과 같습니다.
1. `bookService.getBookTitle(bookId)`를 호출하여 책의 제목을 조회합니다.
2. `localFileService.getBookImage(title)`를 호출하여 로컬 폴더에 저장된 책의 이미지를 가져옵니다.
3. 응답 메시지의 `Content-Type`을 `image/jpeg`로 지정하고 책 이미지를 Body에 담아 응답 메시지를 전달합니다.

이 때 로컬 폴더 경로명은 `application.properties` 파일에 저장하였습니다.
따라서 `LocalFileService`에서 `@value` 어노테이션을 사용하여 `application.properties` 파일에서 `book.folder.path` 값을 주입받고, 이를 `bookFolderPath` 필드에 저장하여 이미지가 저장된 로컬 폴더 경로를 참조하도록 하였습니다.

## 📖 구현 스크린샷
Postman으로 테스트 완료하였습니다.
![image](https://github.com/capstone-focus/FOCUS/assets/63943319/1e6f9a7e-f34b-4aea-aae0-cb8ce30f1db4)
![image](https://github.com/capstone-focus/FOCUS/assets/63943319/43d4da14-87af-4df3-8439-1b9cae2ea026)

실제 브라우저에서도 해당 API로 요청을 보냈을 때 사진이 보내지는 것을 확인하였습니다.
![image](https://github.com/capstone-focus/FOCUS/assets/63943319/e82f83c0-425e-4fdf-b439-e67e841af891)


## 📖 PR 포인트 & 궁금한 점
